### PR TITLE
ratelimit: support returning custom response bodies for non-OK responses from the external ratelimit service, similar to ext_authz.

### DIFF
--- a/api/envoy/service/ratelimit/v2/rls.proto
+++ b/api/envoy/service/ratelimit/v2/rls.proto
@@ -46,6 +46,7 @@ message RateLimitRequest {
 }
 
 // A response from a ShouldRateLimit call.
+// [#next-free-field: 6]
 message RateLimitResponse {
   enum Code {
     // The response code is not known.
@@ -113,4 +114,7 @@ message RateLimitResponse {
 
   // A list of headers to add to the request when forwarded
   repeated api.v2.core.HeaderValue request_headers_to_add = 4;
+
+  // A response body to send to the downstream client when the response code is not OK.
+  string body = 5;
 }

--- a/api/envoy/service/ratelimit/v3/rls.proto
+++ b/api/envoy/service/ratelimit/v3/rls.proto
@@ -67,6 +67,7 @@ message RateLimitRequest {
 }
 
 // A response from a ShouldRateLimit call.
+// [#next-free-field: 6]
 message RateLimitResponse {
   option (udpa.annotations.versioning).previous_message_type =
       "envoy.service.ratelimit.v2.RateLimitResponse";
@@ -144,4 +145,7 @@ message RateLimitResponse {
 
   // A list of headers to add to the request when forwarded
   repeated config.core.v3.HeaderValue request_headers_to_add = 4;
+
+  // A response body to send to the downstream client when the response code is not OK.
+  string body = 5;
 }

--- a/generated_api_shadow/envoy/service/ratelimit/v2/rls.proto
+++ b/generated_api_shadow/envoy/service/ratelimit/v2/rls.proto
@@ -46,6 +46,7 @@ message RateLimitRequest {
 }
 
 // A response from a ShouldRateLimit call.
+// [#next-free-field: 6]
 message RateLimitResponse {
   enum Code {
     // The response code is not known.
@@ -113,4 +114,7 @@ message RateLimitResponse {
 
   // A list of headers to add to the request when forwarded
   repeated api.v2.core.HeaderValue request_headers_to_add = 4;
+
+  // A response body to send to the downstream client when the response code is not OK.
+  string body = 5;
 }

--- a/generated_api_shadow/envoy/service/ratelimit/v3/rls.proto
+++ b/generated_api_shadow/envoy/service/ratelimit/v3/rls.proto
@@ -67,6 +67,7 @@ message RateLimitRequest {
 }
 
 // A response from a ShouldRateLimit call.
+// [#next-free-field: 6]
 message RateLimitResponse {
   option (udpa.annotations.versioning).previous_message_type =
       "envoy.service.ratelimit.v2.RateLimitResponse";
@@ -144,4 +145,7 @@ message RateLimitResponse {
 
   // A list of headers to add to the request when forwarded
   repeated config.core.v3.HeaderValue request_headers_to_add = 4;
+
+  // A response body to send to the downstream client when the response code is not OK.
+  string body = 5;
 }

--- a/source/extensions/filters/common/ratelimit/ratelimit.h
+++ b/source/extensions/filters/common/ratelimit/ratelimit.h
@@ -42,7 +42,8 @@ public:
    * response headers and request headers to be forwarded to the upstream are supplied.
    */
   virtual void complete(LimitStatus status, Http::ResponseHeaderMapPtr&& response_headers_to_add,
-                        Http::RequestHeaderMapPtr&& request_headers_to_add) PURE;
+                        Http::RequestHeaderMapPtr&& request_headers_to_add,
+                        const std::string& response_body) PURE;
 };
 
 /**

--- a/source/extensions/filters/common/ratelimit/ratelimit_impl.cc
+++ b/source/extensions/filters/common/ratelimit/ratelimit_impl.cc
@@ -104,14 +104,14 @@ void GrpcClientImpl::onSuccess(
     }
   }
   callbacks_->complete(status, std::move(response_headers_to_add),
-                       std::move(request_headers_to_add));
+                       std::move(request_headers_to_add), response->body());
   callbacks_ = nullptr;
 }
 
 void GrpcClientImpl::onFailure(Grpc::Status::GrpcStatus status, const std::string&,
                                Tracing::Span&) {
   ASSERT(status != Grpc::Status::WellKnownGrpcStatus::Ok);
-  callbacks_->complete(LimitStatus::Error, nullptr, nullptr);
+  callbacks_->complete(LimitStatus::Error, nullptr, nullptr, "");
   callbacks_ = nullptr;
 }
 

--- a/source/extensions/filters/http/ratelimit/ratelimit.h
+++ b/source/extensions/filters/http/ratelimit/ratelimit.h
@@ -118,7 +118,8 @@ public:
   // RateLimit::RequestCallbacks
   void complete(Filters::Common::RateLimit::LimitStatus status,
                 Http::ResponseHeaderMapPtr&& response_headers_to_add,
-                Http::RequestHeaderMapPtr&& request_headers_to_add) override;
+                Http::RequestHeaderMapPtr&& request_headers_to_add,
+                const std::string &response_body) override;
 
 private:
   void initiateCall(const Http::RequestHeaderMap& headers);
@@ -126,7 +127,7 @@ private:
                                     std::vector<Envoy::RateLimit::Descriptor>& descriptors,
                                     const Router::RouteEntry* route_entry,
                                     const Http::HeaderMap& headers) const;
-  void populateResponseHeaders(Http::HeaderMap& response_headers);
+  void populateResponseHeaders(Http::HeaderMap& response_headers, bool overwrite_content_type);
   void appendRequestHeaders(Http::HeaderMapPtr& request_headers_to_add);
 
   Http::Context& httpContext() { return config_->httpContext(); }

--- a/source/extensions/filters/network/ratelimit/ratelimit.cc
+++ b/source/extensions/filters/network/ratelimit/ratelimit.cc
@@ -70,7 +70,8 @@ void Filter::onEvent(Network::ConnectionEvent event) {
 }
 
 void Filter::complete(Filters::Common::RateLimit::LimitStatus status, Http::ResponseHeaderMapPtr&&,
-                      Http::RequestHeaderMapPtr&&) {
+                      Http::RequestHeaderMapPtr&&,
+                      const std::string&) {
   status_ = Status::Complete;
   config_->stats().active_.dec();
 

--- a/source/extensions/filters/network/ratelimit/ratelimit.h
+++ b/source/extensions/filters/network/ratelimit/ratelimit.h
@@ -93,7 +93,8 @@ public:
   // RateLimit::RequestCallbacks
   void complete(Filters::Common::RateLimit::LimitStatus status,
                 Http::ResponseHeaderMapPtr&& response_headers_to_add,
-                Http::RequestHeaderMapPtr&& request_headers_to_add) override;
+                Http::RequestHeaderMapPtr&& request_headers_to_add,
+                const std::string &response_body) override;
 
 private:
   enum class Status { NotStarted, Calling, Complete };

--- a/source/extensions/filters/network/thrift_proxy/filters/ratelimit/ratelimit.cc
+++ b/source/extensions/filters/network/thrift_proxy/filters/ratelimit/ratelimit.cc
@@ -59,7 +59,8 @@ void Filter::onDestroy() {
 
 void Filter::complete(Filters::Common::RateLimit::LimitStatus status,
                       Http::ResponseHeaderMapPtr&& response_headers_to_add,
-                      Http::RequestHeaderMapPtr&& request_headers_to_add) {
+                      Http::RequestHeaderMapPtr&& request_headers_to_add,
+                      const std::string&) {
   // TODO(zuercher): Store headers to append to a response. Adding them to a local reply (over
   // limit or error) is a matter of modifying the callbacks to allow it. Adding them to an upstream
   // response requires either response (aka encoder) filters or some other mechanism.

--- a/source/extensions/filters/network/thrift_proxy/filters/ratelimit/ratelimit.h
+++ b/source/extensions/filters/network/thrift_proxy/filters/ratelimit/ratelimit.h
@@ -78,7 +78,8 @@ public:
   // RateLimit::RequestCallbacks
   void complete(Filters::Common::RateLimit::LimitStatus status,
                 Http::ResponseHeaderMapPtr&& response_headers_to_add,
-                Http::RequestHeaderMapPtr&& request_headers_to_add) override;
+                Http::RequestHeaderMapPtr&& request_headers_to_add,
+                const std::string& response_body) override;
 
 private:
   void initiateCall(const ThriftProxy::MessageMetadata& metadata);

--- a/test/test_common/utility.h
+++ b/test/test_common/utility.h
@@ -834,6 +834,13 @@ public:
     HeaderMapImpl::copyFrom(*header_map_, rhs);
     header_map_->verifyByteSizeInternalForTest();
   }
+  void copyFrom(const TestHeaderMapImplBase& rhs) {
+    copyFrom(*rhs.header_map_);
+  }
+  void copyFrom(const HeaderMap& rhs) {
+    HeaderMapImpl::copyFrom(*header_map_, rhs);
+    header_map_->verifyByteSizeInternalForTest();
+  }
   TestHeaderMapImplBase& operator=(const TestHeaderMapImplBase& rhs) {
     if (this == &rhs) {
       return *this;


### PR DESCRIPTION
Support returning custom responses bodies for any non-OK response that comes from the external ratelimit service. This behavior is simiar to the ext_authz filter using gRPC.

Today, there are only three possible responses from the ratelimit service: OK, OVER_LIMIT, and an unknown error code. To better support future error codes, we choose to sendLocalReply with a response body as long as the response is !OK.

The new response body field will be added to both v2 and b3 rls proto specs. All existing filters using the common ratelimit implementation are updated, but only the http implementation actually uses the response body. This is similar to how response headers etc are only used by the http implementation.

Changes:
- add response body to v2/rls.proto and v3/rls.proto
- ran 'tools/proto_format/proto_format.sh fix && tools/proto_format/proto_format.sh check'
- update ratelimit complete method to take a response body, but only use it for http
