### PR TITLE
source/extensions/filters/http/response_map: support disabling using per route config

### DIFF
--- a/api/envoy/extensions/filters/http/response_map/v3/response_map.proto
+++ b/api/envoy/extensions/filters/http/response_map/v3/response_map.proto
@@ -81,3 +81,14 @@ message ResponseMap {
   //
   config.core.v3.SubstitutionFormatString body_format = 2;
 }
+
+// Extra settings on a per virtualhost/route/weighted-cluster level.
+message ResponseMapPerRoute {
+  oneof override {
+    option (validate.required) = true;
+
+    // Disable the response map filter for this particular vhost or route.
+    // If disabled is specified in multiple per-filter-configs, the most specific one will be used.
+    bool disabled = 1 [(validate.rules).bool = {const: true}];
+  }
+}

--- a/api/envoy/extensions/filters/http/response_map/v4alpha/response_map.proto
+++ b/api/envoy/extensions/filters/http/response_map/v4alpha/response_map.proto
@@ -87,3 +87,17 @@ message ResponseMap {
   //
   config.core.v4alpha.SubstitutionFormatString body_format = 2;
 }
+
+// Extra settings on a per virtualhost/route/weighted-cluster level.
+message ResponseMapPerRoute {
+  option (udpa.annotations.versioning).previous_message_type =
+      "envoy.extensions.filters.http.response_map.v3.ResponseMapPerRoute";
+
+  oneof override {
+    option (validate.required) = true;
+
+    // Disable the response map filter for this particular vhost or route.
+    // If disabled is specified in multiple per-filter-configs, the most specific one will be used.
+    bool disabled = 1 [(validate.rules).bool = {const: true}];
+  }
+}

--- a/generated_api_shadow/envoy/extensions/filters/http/response_map/v3/response_map.proto
+++ b/generated_api_shadow/envoy/extensions/filters/http/response_map/v3/response_map.proto
@@ -81,3 +81,14 @@ message ResponseMap {
   //
   config.core.v3.SubstitutionFormatString body_format = 2;
 }
+
+// Extra settings on a per virtualhost/route/weighted-cluster level.
+message ResponseMapPerRoute {
+  oneof override {
+    option (validate.required) = true;
+
+    // Disable the response map filter for this particular vhost or route.
+    // If disabled is specified in multiple per-filter-configs, the most specific one will be used.
+    bool disabled = 1 [(validate.rules).bool = {const: true}];
+  }
+}

--- a/generated_api_shadow/envoy/extensions/filters/http/response_map/v4alpha/response_map.proto
+++ b/generated_api_shadow/envoy/extensions/filters/http/response_map/v4alpha/response_map.proto
@@ -87,3 +87,17 @@ message ResponseMap {
   //
   config.core.v4alpha.SubstitutionFormatString body_format = 2;
 }
+
+// Extra settings on a per virtualhost/route/weighted-cluster level.
+message ResponseMapPerRoute {
+  option (udpa.annotations.versioning).previous_message_type =
+      "envoy.extensions.filters.http.response_map.v3.ResponseMapPerRoute";
+
+  oneof override {
+    option (validate.required) = true;
+
+    // Disable the response map filter for this particular vhost or route.
+    // If disabled is specified in multiple per-filter-configs, the most specific one will be used.
+    bool disabled = 1 [(validate.rules).bool = {const: true}];
+  }
+}

--- a/source/extensions/filters/http/response_map/BUILD
+++ b/source/extensions/filters/http/response_map/BUILD
@@ -20,6 +20,7 @@ envoy_cc_library(
         "//include/envoy/http:codes_interface",
         "//include/envoy/http:filter_interface",
         "//source/common/response_map:response_map_lib",
+        "//source/extensions/filters/http:well_known_names",
         "//source/common/buffer:buffer_lib",
         "//source/common/common:assert_lib",
         "//source/common/common:enum_to_int",

--- a/source/extensions/filters/http/response_map/config.cc
+++ b/source/extensions/filters/http/response_map/config.cc
@@ -11,12 +11,21 @@ namespace ResponseMapFilter {
 
 Http::FilterFactoryCb ResponseMapFilterFactory::createFilterFactoryFromProtoTyped(
     const envoy::extensions::filters::http::response_map::v3::ResponseMap& proto_config,
-    const std::string& stats_prefix, Server::Configuration::FactoryContext& context) {
+    const std::string& stats_prefix,
+    Server::Configuration::FactoryContext& context) {
   ResponseMapFilterConfigSharedPtr config =
       std::make_shared<ResponseMapFilterConfig>(proto_config, stats_prefix, context);
   return [config](Http::FilterChainFactoryCallbacks& callbacks) -> void {
     callbacks.addStreamFilter(std::make_shared<ResponseMapFilter>(config));
   };
+}
+
+Router::RouteSpecificFilterConfigConstSharedPtr
+ResponseMapFilterFactory::createRouteSpecificFilterConfigTyped(
+    const envoy::extensions::filters::http::response_map::v3::ResponseMapPerRoute& proto_config,
+    Server::Configuration::ServerFactoryContext&,
+    ProtobufMessage::ValidationVisitor&) {
+  return std::make_shared<FilterConfigPerRoute>(proto_config);
 }
 
 /**

--- a/source/extensions/filters/http/response_map/config.h
+++ b/source/extensions/filters/http/response_map/config.h
@@ -2,6 +2,7 @@
 
 #include "envoy/extensions/filters/http/response_map/v3/response_map.pb.h"
 #include "envoy/extensions/filters/http/response_map/v3/response_map.pb.validate.h"
+#include "envoy/server/filter_config.h"
 
 #include "extensions/filters/http/common/factory_base.h"
 #include "extensions/filters/http/well_known_names.h"
@@ -16,13 +17,20 @@ namespace ResponseMapFilter {
  */
 class ResponseMapFilterFactory
     : public Common::FactoryBase<
-          envoy::extensions::filters::http::response_map::v3::ResponseMap> {
+          envoy::extensions::filters::http::response_map::v3::ResponseMap,
+          envoy::extensions::filters::http::response_map::v3::ResponseMapPerRoute> {
 public:
   ResponseMapFilterFactory() : FactoryBase(HttpFilterNames::get().ResponseMap) {}
 
   Http::FilterFactoryCb createFilterFactoryFromProtoTyped(
       const envoy::extensions::filters::http::response_map::v3::ResponseMap& proto_config,
       const std::string& stats_prefix, Server::Configuration::FactoryContext& context) override;
+
+private:
+  Router::RouteSpecificFilterConfigConstSharedPtr createRouteSpecificFilterConfigTyped(
+      const envoy::extensions::filters::http::response_map::v3::ResponseMapPerRoute& proto_config,
+      Server::Configuration::ServerFactoryContext& context,
+      ProtobufMessage::ValidationVisitor& validator) override;
 };
 
 } // namespace ResponseMapFilter

--- a/source/extensions/filters/http/response_map/response_map_filter.h
+++ b/source/extensions/filters/http/response_map/response_map_filter.h
@@ -25,6 +25,18 @@ private:
 };
 using ResponseMapFilterConfigSharedPtr = std::shared_ptr<ResponseMapFilterConfig>;
 
+class FilterConfigPerRoute : public Router::RouteSpecificFilterConfig {
+public:
+  FilterConfigPerRoute(
+      const envoy::extensions::filters::http::response_map::v3::ResponseMapPerRoute&
+          config)
+      : disabled_(config.disabled()) {}
+  bool disabled() const { return disabled_; }
+
+private:
+  bool disabled_;
+};
+
 class ResponseMapFilter : public Http::StreamFilter, Logger::Loggable<Logger::Id::filter> {
 public:
   ResponseMapFilter(ResponseMapFilterConfigSharedPtr config);
@@ -71,6 +83,7 @@ private:
   Http::ResponseHeaderMap* response_headers_{};
   Http::RequestHeaderMap* request_headers_{};
   bool do_rewrite_{};
+  bool disabled_{};
 };
 
 } // namespace ResponseMapFilter


### PR DESCRIPTION
Copies the pattern in source/extensions/filters/http/grpc_http1_reverse_bridge/*