### PR TITLE
response_map: major bugfix for a filter iteration with no request headers

### DIFF
--- a/source/extensions/filters/http/response_map/response_map_filter.h
+++ b/source/extensions/filters/http/response_map/response_map_filter.h
@@ -60,17 +60,23 @@ private:
  * Otherwise, we wait until encodeData, drain anything we get from the upstream,
  * and finally rewrite the response body.
  *
+ * Not all filter stages are guaranteed to be called. For example, if there are
+ * no request headers to parse (because, for example, Envoy responds locally
+ * with HTTP 426 to upgrade an HTTP/1.0 request before parsing headers), then
+ * decodeHeaders will never be called. Similarly, if there is no upstream
+ * response body, then encodeData will not be called.
+ *
  * The response map filter maintains three pieces of state:
  *
- *   disabled: set to true if a per-route config is found in the decode stage and
- *             the disabled flag is set. this disables rewrite behavior entirely.
+ *   disabled_: set to true if a per-route config is found in the decode stage and
+ *              the disabled flag is set. this disables rewrite behavior entirely.
  *
- *   do_rewrite: set to true if the chosen response mapper matched, and we should
- *               eventually do a response body (and/or header) rewrite.
+ *   do_rewrite_: set to true if the chosen response mapper matched, and we should
+ *                eventually do a response body (and/or header) rewrite.
  *
- *   response_map: set to a pointer to the response map that should be used to match
- *                 and rewrite. if a per-route config is found and its mapper is set,
- *                 use that. otherwise, use the globally configured mapper.
+ *   response_map_: set to a pointer to the response map that should be used to match
+ *                  and rewrite. if a per-route config is found and its mapper is set,
+ *                  use that. otherwise, use the globally configured mapper.
  */
 class ResponseMapFilter : public Http::StreamFilter, Logger::Loggable<Logger::Id::filter> {
 public:


### PR DESCRIPTION
With the fix

```
[~/git/datawire/envoy] [git:esmet/dev/response-map-bugfix] [kube:default]
$ curl --http1.1 -i -k http://0:10000/what
HTTP/1.1 404 Not Found
server: envoy
date: Tue, 03 Nov 2020 19:33:53 GMT
content-type: text/plain
content-length: 64
access-control-allow-origin: *
access-control-allow-credentials: true
x-envoy-upstream-service-time: 110

hello global config: response code 404 with details via_upstream[~/git/datawire/envoy] [git:esmet/dev/response-map-bugfix] [kube:default]
$ curl --http1.0 -i -k http://0:10000/what
HTTP/1.1 426 Upgrade Required
date: Tue, 03 Nov 2020 19:33:57 GMT
server: envoy
connection: close
content-length: 0
```

Logs:
```
[2020-11-03 19:33:53.349][956532][trace][filter] [source/extensions/filters/http/response_map/response_map_filter.cc:66] response map filter: decodeHeaders with end_stream = true
[2020-11-03 19:33:53.462][956532][trace][filter] [source/extensions/filters/http/response_map/response_map_filter.cc:83] response map filter: encodeHeaders with http status = 404, end_stream = false
[2020-11-03 19:33:53.462][956532][trace][filter] [source/extensions/filters/http/response_map/response_map_filter.cc:51] response map filter: found route. has per_route_config? false
[2020-11-03 19:33:53.462][956532][trace][filter] [source/extensions/filters/http/response_map/response_map_filter.cc:126] response map filter: used response_map_, do_rewrite_ = true
[2020-11-03 19:33:53.462][956532][trace][filter] [source/extensions/filters/http/response_map/response_map_filter.cc:173] response map filter: encodeData doing rewrite
[2020-11-03 19:33:53.463][956532][trace][filter] [source/extensions/filters/http/response_map/response_map_filter.cc:181] response map filter: doRewrite with non-null encoding_buffer
[2020-11-03T19:33:53.349Z] "GET /what HTTP/1.1" 404 - 0 64 114 110 "-" "curl/7.68.0" "32300e94-827d-9613-aa31-c3c2d0c759c9" "0:10000" "127.0.0.1:8080"
[2020-11-03 19:33:57.700][956532][trace][filter] [source/extensions/filters/http/response_map/response_map_filter.cc:83] response map filter: encodeHeaders with http status = 426, end_stream = true
[2020-11-03 19:33:57.700][956532][trace][filter] [source/extensions/filters/http/response_map/response_map_filter.cc:126] response map filter: used response_map_, do_rewrite_ = false
[2020-11-03T19:33:57.700Z] "GET /what HTTP/1.0" 426 - 0 0 0 - "-" "curl/7.68.0" "-" "0:10000" "-"
```